### PR TITLE
Add cross-platform CI and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,23 +13,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test (${{ matrix.os }})
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        include:
-          - os: ubuntu-latest
-            run-clippy: true
-    runs-on: ${{ matrix.os }}
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: ${{ matrix.run-clippy && 'clippy' || '' }}
+          components: clippy
       - uses: Swatinem/rust-cache@v2
-      - if: matrix.run-clippy
-        run: cargo clippy -- -D warnings
+      - run: cargo clippy -- -D warnings
+
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: taiki-e/install-action@cargo-audit
+      - run: cargo audit
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: [clippy, audit]
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
   coverage:
@@ -54,15 +67,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --workspace
-
-  audit:
-    name: Audit
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: taiki-e/install-action@cargo-audit
-      - run: cargo audit
 
   complexity:
     name: Complexity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,22 @@ env:
 
 jobs:
   test:
-    name: Clippy & Test
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            run-clippy: true
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: ${{ matrix.run-clippy && 'clippy' || '' }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy -- -D warnings
+      - if: matrix.run-clippy
+        run: cargo clippy -- -D warnings
       - run: cargo test
 
   coverage:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             archive: tar.gz
           - os: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            archive: tar.gz
+          - os: macos-13
+            target: x86_64-apple-darwin
+            archive: tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release -p jetdb-cli
+
+      - name: Package (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: tar czf jetdb-${{ matrix.target }}.tar.gz -C target/release jetdb
+
+      - name: Package (Windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: Compress-Archive -Path target/release/jetdb.exe -DestinationPath jetdb-${{ matrix.target }}.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: jetdb-${{ matrix.target }}
+          path: jetdb-${{ matrix.target }}.${{ matrix.archive }}
+
+  release:
+    name: Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          prerelease=""
+          if echo "$tag" | grep -qE '(alpha|beta|rc)'; then
+            prerelease="--prerelease"
+          fi
+          gh release create "$tag" $prerelease --generate-notes artifacts/*

--- a/crates/jetdb/src/vba.rs
+++ b/crates/jetdb/src/vba.rs
@@ -275,7 +275,8 @@ fn extract_vba_project_cfb(cfb_bytes: Vec<u8>) -> Result<Vec<u8>, FileError> {
     let entries: Vec<(String, bool)> = source
         .walk()
         .filter_map(|e| {
-            let path = e.path().display().to_string();
+            // Use '/' separators regardless of OS (CFB paths are internal, not filesystem)
+            let path = e.path().to_string_lossy().replace('\\', "/");
             if path.starts_with(PREFIX) && path.len() > PREFIX.len() {
                 let relative = &path[PREFIX.len()..];
                 Some((relative.to_string(), e.is_storage()))


### PR DESCRIPTION
## Summary
- Matrix CI test job to run on ubuntu, macOS, and Windows in parallel
- Clippy runs on Ubuntu only (OS-specific lints are rare)
- Add release workflow (`release.yml`): on `v*` tag push, build binaries for 4 targets (linux-x86_64, macos-arm64, macos-x86_64, windows-x86_64) and attach to GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)