### PR TITLE
Add --help-skill flag for AI agent skill support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "jetdb-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,6 +124,14 @@ fn main() -> Result<(), jetdb::FileError> {
 - パスワード保護された .accdb ファイルは `PageReader::open_with_password` が必要 (Agile, RC4 CryptoAPI, Standard/NonStandard AES)
 - レプリケーションデータベース (.mda) は未テスト
 
+## AI エージェント連携
+
+Claude Code などの AI エージェントにスキルとして登録できます:
+
+```bash
+mkdir -p ~/.claude/skills/jetdb-cli && jetdb --help-skill > ~/.claude/skills/jetdb-cli/SKILL.md
+```
+
 ## 謝辞
 
 - MDB/ACCDB ファイルフォーマットの理解にあたって [mdbtools](https://github.com/mdbtools/mdbtools) の [HACKING.md](https://github.com/mdbtools/mdbtools/blob/dev/HACKING.md) を大いに参考にしました

--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ For detailed API documentation and more examples, run `cargo doc --open` or see 
 - Password-protected .accdb files require `PageReader::open_with_password` (Agile, RC4 CryptoAPI, Standard/NonStandard AES)
 - Replication databases (.mda) are untested
 
+## AI Agent Integration
+
+Register as a skill for AI agents like Claude Code:
+
+```bash
+mkdir -p ~/.claude/skills/jetdb-cli && jetdb --help-skill > ~/.claude/skills/jetdb-cli/SKILL.md
+```
+
 ## Acknowledgments
 
 - [mdbtools](https://github.com/mdbtools/mdbtools) — [HACKING.md](https://github.com/mdbtools/mdbtools/blob/dev/HACKING.md) was an invaluable reference for understanding the MDB/ACCDB file format

--- a/crates/jetdb-cli/Cargo.toml
+++ b/crates/jetdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetdb-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "CLI tool for reading Microsoft Access (.mdb/.accdb) files"

--- a/crates/jetdb-cli/src/SKILL.ja.md
+++ b/crates/jetdb-cli/src/SKILL.ja.md
@@ -1,0 +1,195 @@
+---
+name: jetdb-cli
+description: >
+  Microsoft Access データベース (.mdb/.accdb) の読み取り専用 CLI。
+  テーブル一覧、スキーマ表示、CSV エクスポート、DDL 生成
+  (SQLite/PostgreSQL/MySQL/Access)、VBA ソースコード抽出、
+  保存済みクエリの SQL 表示、オブジェクトプロパティ表示が可能。
+  Jet3 (Access 97) から ACE17 (Access 2019) まで対応。
+  パスワード保護・暗号化された .accdb ファイルにも対応。
+  Access から SQL への移行、.mdb ファイルからのデータ抽出、
+  レガシーデータベース構造の調査に使用。
+---
+
+# jetdb CLI
+
+Microsoft Access (.mdb/.accdb) データベースの読み取り専用 CLI。単一バイナリ、ランタイム依存なし。
+
+```
+cargo install jetdb-cli
+```
+
+## クイックリファレンス
+
+```
+jetdb [--password <PASS>] <COMMAND> [OPTIONS] <FILE> [ARGS]
+```
+
+全出力は stdout へ。エラーは stderr に `jetdb:` プレフィックス付きで出力。
+終了コードは成功時 0、エラー時 1。一覧系コマンドはデータなしの場合、空出力で成功 (exit 0)。
+Access のオブジェクト名にはスペースが含まれることが多い — テーブル名、クエリ名、モジュール名の引数は常にクォートすること（例: `jetdb export data.mdb "Order Details"`）。
+
+## コマンド
+
+### ver — エンジンバージョン
+
+```
+jetdb ver <FILE>              # 短縮形: JET3, JET4, ACE12..ACE17
+jetdb ver -l <FILE>           # 詳細: "Jet4 (Access 2000/2003)"
+```
+
+### tables — テーブル一覧
+
+```
+jetdb tables <FILE>           # ユーザーテーブル、1行1件、名前ソート
+jetdb tables -s <FILE>        # システムテーブルを含む
+jetdb tables -T <FILE>        # 種別名 (table/systable) をタブ区切りで前置
+jetdb tables -t <FILE>        # 種別番号をタブ区切りで前置
+```
+
+`-t` と `-T` は排他的。
+
+出力例:
+
+```
+$ jetdb tables -s -T data.mdb
+systable	MSysACEs
+systable	MSysObjects
+table	Customers
+table	Orders
+```
+
+### schema — テーブル構造と DDL
+
+```
+jetdb schema <FILE>                            # 全テーブル、人間可読形式
+jetdb schema <FILE> -T <TABLE>                 # 単一テーブル
+jetdb schema <FILE> --ddl sqlite               # DDL: sqlite|postgres|mysql|access
+jetdb schema <FILE> --no-indexes --no-relations
+```
+
+人間可読形式と DDL の両方でカラム、インデックス、リレーションシップを表示。
+`--no-indexes` と `--no-relations` は両方の出力モードに適用される。
+DDL は CREATE TABLE, CREATE INDEX, ALTER TABLE FOREIGN KEY を生成。
+
+出力例 (人間可読形式):
+
+```
+Table: Customers
+
+  Columns:
+    ID    Long         NOT NULL AUTO
+    Name  Text(100)
+    Email Text(200)
+
+  Indexes:
+    PrimaryKey  [ID ASC]  UNIQUE REQUIRED
+```
+
+### export — CSV エクスポート
+
+```
+jetdb export <FILE> <TABLE>                    # RFC 4180 CSV を stdout へ
+jetdb export <FILE> <TABLE> -H                 # ヘッダー行なし
+jetdb export <FILE> <TABLE> -d "\t"            # タブ区切り
+jetdb export <FILE> <TABLE> -D "%d/%m/%Y"      # 日付フォーマット (strftime)
+jetdb export <FILE> <TABLE> -T "%Y-%m-%dT%H:%M:%S"  # 日時フォーマット
+jetdb export <FILE> <TABLE> -b strip           # バイナリ: strip|raw|octal|hex
+jetdb export <FILE> <TABLE> -0 "NULL"          # NULL の表現文字列
+jetdb export <FILE> <TABLE> -B                 # 真偽値を TRUE/FALSE で出力
+jetdb export <FILE> <TABLE> -s                 # レプリケーション列を含む
+```
+
+テキスト値と GUID は常に引用符付き。数値は引用符なし。
+
+出力例:
+
+```
+ID,Name,Email,Active
+1,"Alice","alice@example.com",1
+2,"Bob","bob@example.com",0
+```
+
+### queries — 保存済みクエリ
+
+```
+jetdb queries list <FILE>                      # スペース区切り、ソート済み
+jetdb queries list -1 <FILE>                   # 1行1件
+jetdb queries show <FILE> <QUERY_NAME>         # SQL 定義を出力
+```
+
+### vba — VBA モジュール
+
+```
+jetdb vba list <FILE>                          # スペース区切り、ソート済み
+jetdb vba list -1 <FILE>                       # 1行1件
+jetdb vba show <FILE> <MODULE_NAME>            # ソースコード全体を出力
+```
+
+### prop — オブジェクトプロパティ
+
+```
+jetdb prop <FILE> <OBJECT_NAME>
+```
+
+LvProp 値をテーブルプロパティ、カラム別、追加プロパティにグループ化して表示。
+
+## 暗号化データベース
+
+.mdb ファイル (Access 97-2003) は Jet RC4 エンコーディングを透過的に処理 — パスワード不要。
+.accdb ファイル (Access 2007+) はパスワードが必要な場合がある:
+
+```
+jetdb --password "secret" tables protected.accdb
+```
+
+`--password` はグローバルオプションで、サブコマンドの前に指定する。
+
+## ワークフローパターン
+
+### データベースの探索
+
+```
+jetdb ver data.mdb
+jetdb tables data.mdb
+jetdb schema data.mdb
+```
+
+### 分析用にエクスポート
+
+```
+jetdb tables data.mdb                          # テーブル名を確認
+jetdb schema data.mdb -T Customers             # カラムを確認
+jetdb export data.mdb Customers > customers.csv
+```
+
+### スキーマを他の RDBMS に移行
+
+```
+jetdb schema data.mdb --ddl postgres > schema.sql
+```
+
+### 全 VBA モジュールの抽出
+
+```
+jetdb vba list -1 data.mdb | while read -r mod; do
+  jetdb vba show data.mdb "$mod" > "${mod}.bas"
+done
+```
+
+### 全保存済みクエリの確認
+
+```
+jetdb queries list -1 data.mdb | while read -r q; do
+  echo "=== $q ==="
+  jetdb queries show data.mdb "$q"
+done
+```
+
+## エラー動作
+
+- ファイルが見つからない / 読み取り不可 → exit 1
+- `show` コマンドでテーブル/クエリ/モジュールが見つからない → exit 1
+- パスワードが必要だが未指定 → exit 1, `PasswordRequired`
+- パスワードが不正 → exit 1, `InvalidPassword`
+- `list` でデータなし → exit 0, stdout は空

--- a/crates/jetdb-cli/src/SKILL.md
+++ b/crates/jetdb-cli/src/SKILL.md
@@ -1,13 +1,195 @@
-# jetdb skill
+---
+name: jetdb-cli
+description: >
+  Read-only CLI for Microsoft Access databases (.mdb/.accdb).
+  List tables, show schemas, export rows as CSV, generate DDL
+  (SQLite/PostgreSQL/MySQL/Access), extract VBA source code,
+  show saved query SQL, and view object properties.
+  Supports Jet3 (Access 97) through ACE17 (Access 2019),
+  including password-protected and encrypted .accdb files.
+  Use when migrating Access to SQL, extracting data from .mdb files,
+  or inspecting legacy database structure.
+---
 
-> Read-only CLI for Microsoft Access databases (.mdb / .accdb)
+# jetdb CLI
 
-## Installation
+Read-only CLI for Microsoft Access (.mdb/.accdb) databases. Single binary, no runtime dependencies.
 
-```bash
+```
 cargo install jetdb-cli
 ```
 
+## Quick Reference
+
+```
+jetdb [--password <PASS>] <COMMAND> [OPTIONS] <FILE> [ARGS]
+```
+
+All output goes to stdout. Errors go to stderr prefixed with `jetdb:`.
+Exit 0 on success, 1 on error. List commands produce empty output (exit 0) when no data exists.
+Access object names often contain spaces — always quote table, query, and module name arguments (e.g., `jetdb export data.mdb "Order Details"`).
+
 ## Commands
 
-TODO: Add detailed command descriptions for AI agents.
+### ver — Engine version
+
+```
+jetdb ver <FILE>              # Short: JET3, JET4, ACE12..ACE17
+jetdb ver -l <FILE>           # Long: "Jet4 (Access 2000/2003)"
+```
+
+### tables — List tables
+
+```
+jetdb tables <FILE>           # User tables, one per line, sorted
+jetdb tables -s <FILE>        # Include system tables
+jetdb tables -T <FILE>        # Prefix type name (table/systable), tab-separated
+jetdb tables -t <FILE>        # Prefix type number, tab-separated
+```
+
+`-t` and `-T` are mutually exclusive.
+
+Output example:
+
+```
+$ jetdb tables -s -T data.mdb
+systable	MSysACEs
+systable	MSysObjects
+table	Customers
+table	Orders
+```
+
+### schema — Table structure and DDL
+
+```
+jetdb schema <FILE>                            # All tables, human-readable
+jetdb schema <FILE> -T <TABLE>                 # Single table
+jetdb schema <FILE> --ddl sqlite               # DDL: sqlite|postgres|mysql|access
+jetdb schema <FILE> --no-indexes --no-relations
+```
+
+Human-readable and DDL output both show Columns, Indexes, and Relationships.
+`--no-indexes` and `--no-relations` apply to both output modes.
+DDL generates CREATE TABLE, CREATE INDEX, and ALTER TABLE FOREIGN KEY.
+
+Output example (human-readable):
+
+```
+Table: Customers
+
+  Columns:
+    ID    Long         NOT NULL AUTO
+    Name  Text(100)
+    Email Text(200)
+
+  Indexes:
+    PrimaryKey  [ID ASC]  UNIQUE REQUIRED
+```
+
+### export — CSV export
+
+```
+jetdb export <FILE> <TABLE>                    # RFC 4180 CSV to stdout
+jetdb export <FILE> <TABLE> -H                 # No header row
+jetdb export <FILE> <TABLE> -d "\t"            # Tab-delimited
+jetdb export <FILE> <TABLE> -D "%d/%m/%Y"      # Custom date format (strftime)
+jetdb export <FILE> <TABLE> -T "%Y-%m-%dT%H:%M:%S"  # Custom datetime
+jetdb export <FILE> <TABLE> -b strip           # Binary: strip|raw|octal|hex
+jetdb export <FILE> <TABLE> -0 "NULL"          # Custom NULL string
+jetdb export <FILE> <TABLE> -B                 # Booleans as TRUE/FALSE
+jetdb export <FILE> <TABLE> -s                 # Include replication columns
+```
+
+Text and GUID values are always quoted. Numeric values are unquoted.
+
+Output example:
+
+```
+ID,Name,Email,Active
+1,"Alice","alice@example.com",1
+2,"Bob","bob@example.com",0
+```
+
+### queries — Saved queries
+
+```
+jetdb queries list <FILE>                      # Space-separated, sorted
+jetdb queries list -1 <FILE>                   # One per line
+jetdb queries show <FILE> <QUERY_NAME>         # Print SQL definition
+```
+
+### vba — VBA modules
+
+```
+jetdb vba list <FILE>                          # Space-separated, sorted
+jetdb vba list -1 <FILE>                       # One per line
+jetdb vba show <FILE> <MODULE_NAME>            # Print full source code
+```
+
+### prop — Object properties
+
+```
+jetdb prop <FILE> <OBJECT_NAME>
+```
+
+Shows LvProp values grouped by: Table Properties, Column (per-column), Additional Properties.
+
+## Encrypted Databases
+
+.mdb files (Access 97-2003) use Jet RC4 encoding handled transparently — no password needed.
+.accdb files (Access 2007+) may require a password:
+
+```
+jetdb --password "secret" tables protected.accdb
+```
+
+`--password` is global and must appear before the subcommand.
+
+## Workflow Patterns
+
+### Explore a database
+
+```
+jetdb ver data.mdb
+jetdb tables data.mdb
+jetdb schema data.mdb
+```
+
+### Export for analysis
+
+```
+jetdb tables data.mdb                          # Find table names
+jetdb schema data.mdb -T Customers             # Check columns
+jetdb export data.mdb Customers > customers.csv
+```
+
+### Migrate schema to another RDBMS
+
+```
+jetdb schema data.mdb --ddl postgres > schema.sql
+```
+
+### Extract all VBA modules
+
+```
+jetdb vba list -1 data.mdb | while read -r mod; do
+  jetdb vba show data.mdb "$mod" > "${mod}.bas"
+done
+```
+
+### Review all saved queries
+
+```
+jetdb queries list -1 data.mdb | while read -r q; do
+  echo "=== $q ==="
+  jetdb queries show data.mdb "$q"
+done
+```
+
+## Error Behavior
+
+- File not found / unreadable → exit 1
+- Table/query/module not found on `show` commands → exit 1
+- Password required but missing → exit 1, `PasswordRequired`
+- Wrong password → exit 1, `InvalidPassword`
+- `list` with no data → exit 0, empty stdout

--- a/crates/jetdb-cli/src/SKILL.md
+++ b/crates/jetdb-cli/src/SKILL.md
@@ -1,0 +1,13 @@
+# jetdb skill
+
+> Read-only CLI for Microsoft Access databases (.mdb / .accdb)
+
+## Installation
+
+```bash
+cargo install jetdb-cli
+```
+
+## Commands
+
+TODO: Add detailed command descriptions for AI agents.

--- a/crates/jetdb-cli/src/main.rs
+++ b/crates/jetdb-cli/src/main.rs
@@ -28,8 +28,12 @@ struct Cli {
     #[arg(long = "password", global = true)]
     password: Option<String>,
 
+    /// Print SKILL.md for AI agents and exit
+    #[arg(long = "help-skill", visible_alias = "export-skill")]
+    help_skill: bool,
+
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
@@ -498,8 +502,22 @@ fn main() -> ExitCode {
         .init();
 
     let cli = Cli::parse();
+
+    if cli.help_skill {
+        print!("{}", include_str!("SKILL.md"));
+        return ExitCode::SUCCESS;
+    }
+
+    let Some(command) = cli.command else {
+        // No subcommand and no --help-skill: show help
+        use clap::CommandFactory;
+        Cli::command().print_help().ok();
+        eprintln!();
+        return ExitCode::FAILURE;
+    };
+
     let password = cli.password;
-    match cli.command {
+    match command {
         Commands::Ver(args) => cmd_ver(args, password.as_deref()),
         Commands::Tables(args) => cmd_tables(args, password.as_deref()),
         Commands::Schema(args) => cmd_schema(args, password.as_deref()),


### PR DESCRIPTION
## Summary

- Add `--help-skill` flag (alias `--export-skill`) that outputs a SKILL.md for AI agents
- SKILL.md is embedded in the binary via `include_str!()` and stays in sync with the CLI
- Covers all 7 subcommands with usage examples, output samples, workflow patterns, encrypted DB handling, and error behavior
- Japanese reference version (SKILL.ja.md) included but not embedded
- Bump jetdb-cli to 0.2.2

### Usage

```bash
jetdb --help-skill > .claude/skills/jetdb-cli/SKILL.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)