### PR TITLE
Fix crack_row_jet4 overflow panic when var-offset table wraps

### DIFF
--- a/crates/jetdb/src/data.rs
+++ b/crates/jetdb/src/data.rs
@@ -239,9 +239,18 @@ fn crack_row_jet4(row_data: &[u8]) -> Result<CrackedRow<'_>, FileError> {
     let offset_entries = var_col_count as usize + 1;
     let mut var_offsets = Vec::with_capacity(offset_entries);
     for i in 0..offset_entries {
+        // `wrapping_sub` keeps us from panicking when the offset
+        // table would extend past the start of the row. When that
+        // happens `pos` wraps to a near-`usize::MAX` value; the
+        // `pos + 2 > len` check below MUST use `checked_add` so
+        // the compare itself doesn't overflow-panic in debug
+        // (the original code's `pos + 2` did exactly that, which
+        // is how MM's ScoringImprovement / ScoreLanes tables were
+        // bringing down every parser run).
         let pos = vcc_pos.wrapping_sub(2 + i * 2);
-        if pos + 2 > len {
-            break;
+        match pos.checked_add(2) {
+            Some(end) if end <= len => {}
+            _ => break,
         }
         var_offsets.push(u16::from_le_bytes([row_data[pos], row_data[pos + 1]]));
     }
@@ -881,6 +890,36 @@ mod tests {
         // Backward read: var_offsets[0]=6 (start), var_offsets[1]=10 (end)
         assert_eq!(cracked.var_offsets, vec![6, 10]);
         assert_eq!(cracked.null_mask, &[0xFF]);
+    }
+
+    #[test]
+    fn crack_row_jet4_bogus_var_col_count_does_not_overflow() {
+        // Regression: a row whose `var_col_count` claims more
+        // variable columns than physically fit in the row would
+        // make the backward-walking offset-table loop compute a
+        // `pos` that `wrapping_sub` drove below zero. The old
+        // bounds check `pos + 2 > len` then overflow-panicked in
+        // debug before the comparison could reject the wrapped
+        // value. `checked_add` makes the bounds check itself
+        // panic-safe so the loop just breaks cleanly.
+        //
+        // Forward layout (7 bytes total):
+        //   [0x01, 0x00]        ← col_count = 1
+        //   [0x42, 0x42]        ← 2 bytes of payload
+        //   [0x64, 0x00]        ← var_col_count = 100 (bogus)
+        //   [0xFF]              ← null_mask (1 byte)
+        //
+        // vcc_pos = 4, so the backward walk starts at pos = 2, 0,
+        // then wraps on i=2. Old code panicked; new code must
+        // return Ok with however many valid offsets it read.
+        let row: &[u8] = &[0x01, 0x00, 0x42, 0x42, 0x64, 0x00, 0xFF];
+
+        let cracked = crack_row_jet4(row).expect("must not panic on wrap");
+        assert_eq!(cracked.col_count, 1);
+        assert_eq!(cracked.var_col_count, 100);
+        // Only 2 offsets fit before pos wraps; the loop must break
+        // at that point rather than panic.
+        assert_eq!(cracked.var_offsets.len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## What

`crack_row_jet4` (`crates/jetdb/src/data.rs:243`) panics in debug builds with `attempt to add with overflow` on rows where the declared `var_col_count` claims more variable columns than physically fit before `vcc_pos`. `pos` is already computed with `wrapping_sub` (correct), but the very next line — `if pos + 2 > len` — does a plain `usize + 2`, and when `pos` has wrapped to near `usize::MAX` that add itself panics before the length check can reject it.

## Reproducer

Any `.mdb` whose variable-length offset table would extend past the start of the row. I hit it in the wild on Hy-Tek Meet Manager 8 `.mdb` exports — specifically the `ScoringImprovement` and `ScoreLanes` tables of a 2025 meet file.

The included regression test (`crack_row_jet4_bogus_var_col_count_does_not_overflow`) builds a 7-byte synthetic row with `var_col_count = 100` which forces the loop well past `vcc_pos`. Without the fix it panics on the third iteration; with the fix it cleanly breaks out of the loop and returns `Ok` with the two valid offsets that actually fit.

## Fix

Swap `pos + 2 > len` for `pos.checked_add(2)` so the bounds check itself is panic-safe:

```rust
match pos.checked_add(2) {
    Some(end) if end <= len => {}
    _ => break,
}
```

Semantically equivalent for every non-wrapped `pos`; the only difference is that a wrapped `pos` now breaks out of the loop instead of overflow-panicking in debug.

## Verification

- `cargo test -p jetdb --lib` — 620 tests pass (was 619, +1 for the new regression test)
- `cargo test -p jetdb --lib data::tests::crack_row_jet4` — 6/6 pass

Happy to adjust the test fixture, split the test into its own `#[test]`, or add a fuzz-target-style input if you'd prefer.
