### PR TITLE
Bump version to v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "jetdb"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aes",
  "base64",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "jetdb-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "env_logger",

--- a/crates/jetdb-cli/Cargo.toml
+++ b/crates/jetdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetdb-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "CLI tool for reading Microsoft Access (.mdb/.accdb) files"
@@ -19,5 +19,5 @@ doc = false
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 env_logger = "0.11"
-jetdb = { version = "0.3.1", path = "../jetdb" }
+jetdb = { version = "0.3.2", path = "../jetdb" }
 log = "0.4"

--- a/crates/jetdb/Cargo.toml
+++ b/crates/jetdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jetdb"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Pure Rust library for reading Microsoft Access (.mdb/.accdb) files"


### PR DESCRIPTION
## Summary

Bump workspace crate versions to 0.3.2 in preparation for release. Includes the correctness fixes from #8 and #9, plus the CLI adjustments from #10's skill migration. Handwritten release notes will be applied with `gh release edit` after the tag push triggers the automated release creation.